### PR TITLE
Homepage changes

### DIFF
--- a/public/stylesheets/index.css
+++ b/public/stylesheets/index.css
@@ -7,30 +7,15 @@ body {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
-    /* overflow: hidden; */
+    overflow: hidden;
     font-size: 10px;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
-@media only screen and (max-width: 1197px) {
-    .links-container {
-        display: none;
-    }
-}
-
-@media only screen and (max-width: 1085px) {
-    video {
-        display: none;
-    }
-    body {
-        background-color: #222629;
-    }
-}
-
 .recommended {
-    /* position: absolute; */
+    position: absolute;
     left: 30px;
-    top: 55px;
+    top: 60px;
     background-color: #2B2B2B;
     width: 400px;
     padding: 10px;
@@ -38,11 +23,15 @@ body {
     border: 2px solid #5A5A5A;
     text-decoration: none;
     color: white;
+    z-index: 999999999999999999999999999;
 }
 
 .allContainer {
     padding: 10px;
+    top: 100px;
+    left: -12px;
     height: fit-content;
+    position: absolute;
     width: 1200px;
     display: grid;
     grid-template-rows: 1fr 1fr 1fr;
@@ -173,4 +162,19 @@ a {
 
 h2.trail-state {
     font-size: 0.9em;
+}
+
+@media only screen and (max-width: 1197px) {
+    .links-container {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 1085px) {
+    video {
+        display: none;
+    }
+    body {
+        background-color: #222629;
+    }
 }

--- a/public/stylesheets/navbar.css
+++ b/public/stylesheets/navbar.css
@@ -64,6 +64,7 @@ body {
 /* Navbar Logo Text */
 
 .nav__logo {
+    text-decoration: none;
     margin-left: -20px;
     margin-right: 20px;
     font-size: 40px;

--- a/public/stylesheets/trail.css
+++ b/public/stylesheets/trail.css
@@ -59,6 +59,7 @@ button:not(:disabled):not(.disabled) {
   margin: auto;
   display: flex;
   flex-flow: row nowrap;
+  z-index: -919191919191919px;
   /* height: 1000px; */
   /* grid-template-columns: 1fr 3fr;
   grid-template-areas: "banner" "content"; */

--- a/views/landing.pug
+++ b/views/landing.pug
@@ -8,12 +8,12 @@ block content
     </video>
     div.recommended
       h2 Here are some recommended trails for you:
-    div.allContainer
-    div.links-container
-      h2 View trails in your state:
-        div.state-links
-          each state in states
-            a(href=`/states/${state.dataValues.state_code}`)  #{state.dataValues.state_code}
+      div.allContainer
+    //- div.links-container
+    //-   h2 View trails in your state:
+    //-     div.state-links
+    //-       each state in states
+    //-         a(href=`/states/${state.dataValues.state_code}`)  #{state.dataValues.state_code}
 
 append head
   //- add page specific styles by appending to the head


### PR DESCRIPTION
# Homepage
- Fixed video pushing all other content beneath so that the random trails can be seen.
- Removed 50 states container from homepage. 
- Fixed underline that would appear beneath the logo on certain pages. 